### PR TITLE
Support binary data instead of only string (keys & values)

### DIFF
--- a/DB.cs
+++ b/DB.cs
@@ -50,7 +50,7 @@ namespace LevelDB
     /// If two threads share such an object, they must protect access to it
     /// using their own locking protocol.
     /// </remarks>
-    public class DB : IDisposable, IEnumerable<KeyValuePair<string, string>>
+    public class DB : IDisposable, IEnumerable<KeyValuePair<byte[], byte[]>>
     {
         /// <summary>
         /// Native handle
@@ -59,7 +59,7 @@ namespace LevelDB
         Options Options { get; set; }
         bool Disposed { get; set; }
 
-        public string this[string key] {
+        public byte[] this[byte[] key] {
             get {
                 return Get(null, key);
             }
@@ -137,7 +137,7 @@ namespace LevelDB
             Native.leveldb_destroy_db(options.Handle, path);
         }
 
-        public void Put(WriteOptions options, string key, string value)
+        public void Put(WriteOptions options, byte[] key, byte[] value)
         {
             CheckDisposed();
             if (options == null) {
@@ -146,12 +146,12 @@ namespace LevelDB
             Native.leveldb_put(Handle, options.Handle, key, value);
         }
 
-        public void Put(string key, string value)
+        public void Put(byte[] key, byte[] value)
         {
             Put(null, key, value);
         }
 
-        public void Delete(WriteOptions options, string key)
+        public void Delete(WriteOptions options, byte[] key)
         {
             CheckDisposed();
             if (options == null) {
@@ -160,7 +160,7 @@ namespace LevelDB
             Native.leveldb_delete(Handle, options.Handle, key);
         }
 
-        public void Delete(string key)
+        public void Delete(byte[] key)
         {
             Delete(null, key);
         }
@@ -182,7 +182,7 @@ namespace LevelDB
             Write(null, writeBatch);
         }
 
-        public string Get(ReadOptions options, string key)
+        public byte[] Get(ReadOptions options, byte[] key)
         {
             CheckDisposed();
             if (options == null) {
@@ -191,7 +191,7 @@ namespace LevelDB
             return Native.leveldb_get(Handle, options.Handle, key);
         }
 
-        public string Get(string key)
+        public byte[] Get(byte[] key)
         {
             return Get(null, key);
         }
@@ -201,7 +201,7 @@ namespace LevelDB
             return GetEnumerator();
         }
 
-        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        public IEnumerator<KeyValuePair<byte[], byte[]>> GetEnumerator()
         {
             CheckDisposed();
             return new Iterator(this, null);
@@ -238,7 +238,7 @@ namespace LevelDB
         /// <param name="limitKey">
         /// null is treated as a key after all keys in the database
         /// </param>
-        public void CompactRange(string startKey, string limitKey)
+        public void CompactRange(byte[] startKey, byte[] limitKey)
         {
             CheckDisposed();
             Native.leveldb_compact_range(Handle, startKey, limitKey);

--- a/Iterator.cs
+++ b/Iterator.cs
@@ -43,7 +43,7 @@ namespace LevelDB
     /// If two threads share this object, they must protect access to it using
     /// their own locking protocol.
     /// </remarks>
-    public class Iterator : IEnumerator<KeyValuePair<string, string>>
+    public class Iterator : IEnumerator<KeyValuePair<byte[], byte[]>>
     {
         /// <summary>
         /// Native handle
@@ -59,13 +59,13 @@ namespace LevelDB
             }
         }
 
-        public string Key {
+        public byte[] Key {
             get {
                 return Native.leveldb_iter_key(Handle);
             }
         }
 
-        public string Value {
+        public byte[] Value {
             get {
                 return Native.leveldb_iter_value(Handle);
             }
@@ -77,9 +77,9 @@ namespace LevelDB
             }
         }
 
-        public KeyValuePair<string, string> Current {
+        public KeyValuePair<byte[], byte[]> Current {
             get {
-                return new KeyValuePair<string, string>(Key, Value);
+                return new KeyValuePair<byte[], byte[]>(Key, Value);
             }
         }
 
@@ -115,7 +115,7 @@ namespace LevelDB
             Native.leveldb_iter_seek_to_last(Handle);
         }
 
-        public void Seek(string key)
+        public void Seek(byte[] key)
         {
             Native.leveldb_iter_seek(Handle, key);
         }

--- a/WriteBatch.cs
+++ b/WriteBatch.cs
@@ -69,13 +69,13 @@ namespace LevelDB
             Native.leveldb_writebatch_destroy(Handle);
         }
 
-        public WriteBatch Put(string key, string value)
+        public WriteBatch Put(byte[] key, byte[] value)
         {
             Native.leveldb_writebatch_put(Handle, key, value);
             return this;
         }
 
-        public WriteBatch Delete(string key)
+        public WriteBatch Delete(byte[] key)
         {
             Native.leveldb_writebatch_delete(Handle, key);
             return this;

--- a/leveldb-sharp.csproj
+++ b/leveldb-sharp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>

--- a/leveldb-sharp.sln
+++ b/leveldb-sharp.sln
@@ -1,24 +1,101 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22310.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "leveldb-sharp", "leveldb-sharp.csproj", "{8DD96596-38AC-46DD-80C1-75D9EBE585EA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "leveldb-sharp-tests", "leveldb-sharp-tests.csproj", "{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "leveldb", "..\leveldb\leveldb.vcxproj", "{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|Win32 = Debug|Win32
+		MinSizeRel|Any CPU = MinSizeRel|Any CPU
+		MinSizeRel|Mixed Platforms = MinSizeRel|Mixed Platforms
+		MinSizeRel|Win32 = MinSizeRel|Win32
 		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|Win32 = Release|Win32
+		RelWithDebInfo|Any CPU = RelWithDebInfo|Any CPU
+		RelWithDebInfo|Mixed Platforms = RelWithDebInfo|Mixed Platforms
+		RelWithDebInfo|Win32 = RelWithDebInfo|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Debug|Win32.Build.0 = Debug|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.MinSizeRel|Any CPU.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.MinSizeRel|Any CPU.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.MinSizeRel|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.MinSizeRel|Mixed Platforms.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.MinSizeRel|Win32.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.MinSizeRel|Win32.Build.0 = Release|Any CPU
 		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Release|Win32.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.Release|Win32.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.RelWithDebInfo|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.RelWithDebInfo|Mixed Platforms.Build.0 = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.RelWithDebInfo|Win32.ActiveCfg = Release|Any CPU
+		{8DD96596-38AC-46DD-80C1-75D9EBE585EA}.RelWithDebInfo|Win32.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Debug|Win32.Build.0 = Debug|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.MinSizeRel|Any CPU.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.MinSizeRel|Any CPU.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.MinSizeRel|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.MinSizeRel|Mixed Platforms.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.MinSizeRel|Win32.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.MinSizeRel|Win32.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Win32.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.Release|Win32.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.RelWithDebInfo|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.RelWithDebInfo|Mixed Platforms.Build.0 = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.RelWithDebInfo|Win32.ActiveCfg = Release|Any CPU
+		{35DFF1F0-743A-42BB-8C04-2FDFAEB13587}.RelWithDebInfo|Win32.Build.0 = Release|Any CPU
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Debug|Win32.Build.0 = Debug|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.MinSizeRel|Any CPU.ActiveCfg = MinSizeRel|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.MinSizeRel|Mixed Platforms.ActiveCfg = MinSizeRel|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.MinSizeRel|Mixed Platforms.Build.0 = MinSizeRel|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.MinSizeRel|Win32.ActiveCfg = MinSizeRel|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.MinSizeRel|Win32.Build.0 = MinSizeRel|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Release|Any CPU.ActiveCfg = Release|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Release|Win32.ActiveCfg = Release|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.Release|Win32.Build.0 = Release|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.RelWithDebInfo|Any CPU.ActiveCfg = RelWithDebInfo|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.RelWithDebInfo|Mixed Platforms.ActiveCfg = RelWithDebInfo|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.RelWithDebInfo|Mixed Platforms.Build.0 = RelWithDebInfo|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.RelWithDebInfo|Win32.ActiveCfg = RelWithDebInfo|Win32
+		{D1A5570F-42C4-4DF1-B0D0-6F5AFE433F8F}.RelWithDebInfo|Win32.Build.0 = RelWithDebInfo|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = leveldb-sharp.csproj


### PR DESCRIPTION
leveldb allows arbitray binary arrays for their keys and values. This pull request modifies the C# wrapper to allow for null values in the database.
